### PR TITLE
TST: enforce 100% coverage on Python code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         uv tool install coverage
         coverage combine
         coverage html --skip-covered --skip-empty
-        coverage report --fail-under=99 # >> $GITHUB_STEP_SUMMARY
+        coverage report --fail-under=100 # >> $GITHUB_STEP_SUMMARY
 
     - name: Upload HTML report if check failed.
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/src/rlic/__init__.py
+++ b/src/rlic/__init__.py
@@ -46,9 +46,6 @@ def convolve(
             f"{dtype_error_expectations}"
         )
 
-    if len(input_dtypes) != 1:
-        raise TypeError(f"Data types mismatch. {dtype_error_expectations}")
-
     if image.ndim != 2:
         raise ValueError(
             f"Expected an image with exactly two dimensions. Got {image.ndim=}"


### PR DESCRIPTION
drop the one line that cannot be covered at the moment. I'll move it to #16 instead.