### PR TITLE
TST: enable tests against intermediate Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         - windows-latest
         python-version:
         - 3.9
-        #- '3.10'
-        #- '3.11'
-        #- '3.12'
+        - '3.10'
+        - '3.11'
+        - '3.12'
         - '3.13'
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I just received a notification from GitHub that I used 75% of my free plan *as I prepared this PR* so I will
- cancel its run
- wait until the repo is stabilized before I merge it
