### PR TITLE
RFC: avoid repetition between forward and backward subloops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "either"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +226,7 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 name = "rlic"
 version = "0.2.2"
 dependencies = [
+ "either",
  "num-traits",
  "numpy",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.23.4", features = ["extension-module", "abi3-py39"] }
 numpy = "0.23.0"
 num-traits = "0.2.19"
+either = "1.14.0"
 
 [profile.release]
 # https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units


### PR DESCRIPTION
end goal: avoid duplicating the bulk of the business logic in the main loop. I think this will require defining a closure.
At the time of opening, I'm only taking a first step in this direction by making the different parts use operators programmatically instead of hard coding them.
A remaining difference that I don't know how to refactor off-hand is that the backward (second) loop reverts the velocity field (`let mp = ...`).