### PR TITLE
PERF: disable build parallelism, to the benefit of runtime performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- PERF: disable build parallelism to the benefit of runtime performance
+  (expect about 5 to 10% gain)
+
 ## 0.2.2 - 2025-03-01
 
 - BUG: fix a defect in polarization mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.23.4", features = ["extension-module", "abi3-py39"] }
 numpy = "0.23.0"
 num-traits = "0.2.19"
+
+[profile.release]
+# https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units
+codegen-units = 1


### PR DESCRIPTION
The gain is modest, but it's basically free: compile time is already very short, so I can affort making it a bit longer, and binary size doesn't appear to be affected.