### PR TITLE
TST: test against reference implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,29 @@ jobs:
         if-no-files-found: ignore
         include-hidden-files: true
 
+  regression-tests:
+    name: Regression tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287 # v5.3.0
+      with:
+        python-version: 3.13
+        enable-cache: true
+        prune-cache: false
+    - run: uv sync --group covcheck
+    - name: install reference implementation
+      run: uv pip install git+https://github.com/neutrinoceros/scikits-vectorplot.git
+    - name: Test
+      run: uv run --no-sync coverage run --parallel-mode -m pytest --color=yes -k regression
+    - name: Upload coverage data
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      with:
+        name: rlic_coverage_data-regression-tests
+        path: .coverage.*
+        if-no-files-found: ignore
+        include-hidden-files: true
+
   minimal-env:
     name: Minimal requirements
     runs-on: ubuntu-22.04
@@ -230,7 +253,9 @@ jobs:
   python-coverage:
     name: Combine & check coverage.
     runs-on: ubuntu-latest
-    needs: python-tests
+    needs:
+    - python-tests
+    - regression-tests
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,80 @@
+from itertools import product
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import rlic
+
+pytest.importorskip("vectorplot")
+from vectorplot.lic_internal import (  # noqa: E402
+    line_integral_convolution as reference_impl,
+)
+
+NX, NY = SHAPE = (31, 33)
+rng = np.random.default_rng(0)
+texture = rng.random(SHAPE, dtype="float32")
+
+ONE = np.ones_like(texture)
+ZERO = np.zeros_like(texture)
+
+# define velocity components with a sharp divergence
+ii = np.broadcast_to(np.arange(NY), SHAPE)
+cond = ii < NY / 2
+U1 = np.where(cond, -ONE, ONE)
+
+jj = np.broadcast_to(np.atleast_2d(np.arange(NX)).T, SHAPE)
+cond = jj < NX / 2
+V1 = np.where(cond, -ONE, ONE)
+
+KL = min(NX, NY)
+K0 = np.sin(np.arange(KL) * np.pi / KL, dtype="float32")
+
+test_cases = sorted(
+    (u, v, k, uv_mode)
+    for u, v, k, uv_mode in product(["u0", "u1"], ["v0", "v1"], ["k0"], ["vel", "pol"])
+)
+
+
+@pytest.fixture(params=test_cases)
+def known_answer(request):
+    field_u, field_v, field_kernel, field_mode = request.param
+    if field_u == "u0":
+        u = ZERO
+    elif field_u == "u1":
+        u = U1
+    else:
+        raise RuntimeError  # pragma: no cover
+
+    if field_v == "v0":
+        v = ZERO
+    elif field_v == "v1":
+        v = V1
+    else:
+        raise RuntimeError  # pragma: no cover
+
+    if field_kernel == "k0":
+        kernel = K0
+    else:
+        raise RuntimeError  # pragma: no cover
+
+    if field_mode == "vel":
+        uv_mode = "velocity"
+    elif field_mode == "pol":
+        uv_mode = "polarization"
+    else:
+        raise RuntimeError  # pragma: no cover
+
+    return (
+        u,
+        v,
+        kernel,
+        uv_mode,
+        reference_impl(u, v, texture, kernel, int(uv_mode == "polarization")),
+    )
+
+
+def test_outputs(known_answer):
+    u, v, kernel, uv_mode, expected = known_answer
+    out = rlic.convolve(texture, u, v, kernel=kernel, uv_mode=uv_mode)
+    assert_allclose(out, expected, rtol=1.5e-7, atol=1e-6)


### PR DESCRIPTION
Close #4
Close #47

Note that the reference implementation doesn't support double precision inputs.

TODO:
- [x] survive CI (with tests passing)
- [x] add more test cases from #47
- [x] replace git submodule with a source install