### PR TITLE
PERF: avoid branching in `update_state`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,13 +168,20 @@ fn update_state<T: AtLeastF32>(
     frac_orthogonal: &mut T,
     time_parallel: &T,
 ) {
+    let one: T = 1.0.into();
+    let two: T = 2.0.into();
     if *velocity_parallel >= 0.0.into() {
         *coord_parallel += 1;
-        *frac_parallel = 0.0.into();
     } else {
         *coord_parallel -= 1;
-        *frac_parallel = 1.0.into();
     }
+    // branchless version of
+    // if velocity_parallel >= 0.0 {
+    //     *frac_parallel = 0.0;
+    // } else {
+    //     *frac_parallel = 1.0;
+    // }
+    *frac_parallel = one - (one + signum(*velocity_parallel)) / two;
     *frac_orthogonal = (*time_parallel).mul_add(*velocity_orthogonal, *frac_orthogonal);
 }
 


### PR DESCRIPTION
Eliminiating the branching completely is harder because `coord_parallel` requires an `i64` increment, and casting from the generic type `T` is not possible (out of the box ?).
This cannot be merged until completed.