### PR TITLE
ENH: terminate streamline integration when a NaN vector component is encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - DOC: prefer using a convex kernel shape in examples
+- ENH: terminate streamline integration when a NaN vector component is encountered
 
 ## 0.3.1 - 2025-03-04
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,9 @@ fn convole_single_pixel<T: AtLeastF32>(
             u: ps.get_v(&uvfield.u, &coords, dims),
             v: ps.get_v(&uvfield.v, &coords, dims),
         };
+        if p.u.is_nan() || p.v.is_nan() {
+            break;
+        }
         match uvfield.mode {
             UVMode::Polarization => {
                 if (p.u * last_p.u + p.v * last_p.v) < 0.0.into() {

--- a/src/rlic/_lib.py
+++ b/src/rlic/_lib.py
@@ -113,6 +113,12 @@ def convolve(
 
     It is recommended (but not required) to use odd-sized kernels, so that
     forward and backward passes are balanced.
+
+    No effort is made to avoid progpagation of NaNs from the input texture.
+    However, streamlines will be terminated whenever a pixel where either u or v
+    contains a NaN.
+
+    Infinite values in any input array are not special cased.
     """
     if iterations < 0:
         raise ValueError(


### PR DESCRIPTION
Close #97
I need to add tests for this, but I wanted to commit to this implementation early because performance overhead seems minimal (~<1% from my estimate)
