### PR TITLE
ENH: explicitly forbid non-finite values in kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - DOC: prefer using a convex kernel shape in examples
 - ENH: terminate streamline integration when a NaN vector component is encountered
+- ENH: explicitly forbid non-finite values in `kernel`
 
 ## 0.3.1 - 2025-03-04
 

--- a/src/rlic/_lib.py
+++ b/src/rlic/_lib.py
@@ -58,8 +58,8 @@ def convolve(
 ) -> NDArray[FloatT]:
     """2-dimensional line integral convolution.
 
-    Apply Line Integral Convolution to a texture array, against a 2D flow
-    (u, v) and via a 1D kernel.
+    Apply Line Integral Convolution to a texture array, against a 2D flow (u, v)
+    and via a 1D kernel.
 
     Arguments
     ---------
@@ -83,9 +83,9 @@ def convolve(
       effectively ignored.
 
     iterations: (positive) int (default: 1)
-      Perform multiple iterations in a loop where the output array texture
-      is fed back as the input to the next iteration.
-      Looping is done at the native-code level.
+      Perform multiple iterations in a loop where the output array texture is
+      fed back as the input to the next iteration. Looping is done at the
+      native-code level.
 
     Returns
     -------
@@ -113,6 +113,9 @@ def convolve(
 
     It is recommended (but not required) to use odd-sized kernels, so that
     forward and backward passes are balanced.
+
+    Kernels cannot contain non-finite (infinite or NaN) values. Although
+    unusual, negative values are allowed.
 
     No effort is made to avoid progpagation of NaNs from the input texture.
     However, streamlines will be terminated whenever a pixel where either u or v
@@ -166,6 +169,8 @@ def convolve(
         raise ValueError(
             f"Expected a kernel with exactly one dimension. Got {kernel.ndim=}"
         )
+    if np.any(~np.isfinite(kernel)):
+        raise ValueError("Found non-finite value(s) in kernel.")
 
     input_dtype = texture.dtype
     cc: ConvolveClosure[FloatT]

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -81,6 +81,17 @@ def test_invalid_kernel_ndim():
         rlic.convolve(img, u, v, kernel=np.ones((5, 5)))
 
 
+@pytest.mark.parametrize("polluting_value", [-np.inf, np.inf, np.nan])
+def test_non_finite_kernel(polluting_value):
+    kernel = np.ones(11)
+    kernel[5] = polluting_value
+    with pytest.raises(
+        ValueError,
+        match=r"^Found non-finite value\(s\) in kernel\.$",
+    ):
+        rlic.convolve(img, u, v, kernel=kernel)
+
+
 def test_invalid_texture_dtype():
     img = np.ones((64, 64), dtype="complex128")
     with pytest.raises(


### PR DESCRIPTION
A logical continuation to #101