### PR TITLE
ENH: report all exceptions instead of just the first one when validating inputs, on Python 3.11 and newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - BUG: fix a typo in a user visible error message
+- ENH: report all exceptions instead of just the first one when validating inputs, on
+  Python 3.11 and newer
 
 ## 0.3.2 - 2025-03-07
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ exclude_lines = [
 
 [tool.pyright]
 reportImplicitStringConcatenation = false
+reportUnnecessaryTypeIgnoreComment = false # todo: drop this when Python 3.10 is EOL
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
close #106
this is unstable at the moment because some test cases already meet more than one invalidation clauses and I'm not sure yet how to best adapt them.