### PR TITLE
TST: inspect core module location in pytest header

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 from importlib.metadata import version
+from importlib.util import find_spec
 
 
 def pytest_report_header(config, start_path):
@@ -8,4 +9,5 @@ def pytest_report_header(config, start_path):
     return [
         f"{is_gil_enabled = }",
         f"NumPy: {version('numpy')}",
+        f"rlic._core loads from {find_spec('rlic._core').origin}",
     ]


### PR DESCRIPTION
This makes it trivial to inspect whether the extension was built in abi3 or not