### PR TITLE
TYP: let mypy typecheck against runtime-detected Python, rather than hardcoded oldest supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ reportImplicitStringConcatenation = false
 reportUnnecessaryTypeIgnoreComment = false # todo: drop this when Python 3.10 is EOL
 
 [tool.mypy]
-python_version = "3.9"
 show_error_codes = true
 show_error_context = true
 


### PR DESCRIPTION
This resolves an error when typechecking against numpy 2.3.0, which doesn't support Python 3.9 or 3.10