### PR TITLE
TST: don't cache dev dependencies in CI and don't build vectorplot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,23 +241,16 @@ jobs:
     steps:
     - name: Checkout Source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-      with:
-        # numpy cp314 nightlies require at least 3.14.0b1, which is not available
-        # via uv at the time of writing.
-        python-version: '3.14'
-        allow-prereleases: true
     - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
       with:
-        enable-cache: true
-        prune-cache: false
-        cache-suffix: test
+        python-version: '3.14'
+        enable-cache: false
     - name: Configure uv
       run: |
         echo "UV_PRERELEASE=allow" >> $GITHUB_ENV
         echo "UV_INDEX=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" >> $GITHUB_ENV
         echo "UV_INDEX_STRATEGY=unsafe-best-match" >> $GITHUB_ENV
-    - run: uv sync --no-editable --group test
+    - run: uv sync --no-editable --no-default-groups --group test
     - name: Test
       run: uv run --no-sync pytest --color=yes
 


### PR DESCRIPTION
This test job takes 3min to build when it should be seconds.