### PR TITLE
RFC: split `UVMode::parse` into its own function

### DIFF
--- a/src/rlic/_core.pyi
+++ b/src/rlic/_core.pyi
@@ -9,14 +9,14 @@ def convolve_f32(
     u: ndarray[tuple[int, int], dtype[f32]],
     v: ndarray[tuple[int, int], dtype[f32]],
     kernel: ndarray[tuple[int], dtype[f32]],
-    iterations: int = 1,
     uv_mode: Literal["velocity", "polarization"] = "velocity",
+    iterations: int = 1,
 ) -> ndarray[tuple[int, int], dtype[f32]]: ...
 def convolve_f64(
     texture: ndarray[tuple[int, int], dtype[f64]],
     u: ndarray[tuple[int, int], dtype[f64]],
     v: ndarray[tuple[int, int], dtype[f64]],
     kernel: ndarray[tuple[int], dtype[f64]],
-    iterations: int = 1,
     uv_mode: Literal["velocity", "polarization"] = "velocity",
+    iterations: int = 1,
 ) -> ndarray[tuple[int, int], dtype[f64]]: ...

--- a/src/rlic/_lib.py
+++ b/src/rlic/_lib.py
@@ -183,8 +183,8 @@ def convolve(
     # mypy ignores can be removed once Python 3.9 is dropped.
     # https://github.com/numpy/numpy/issues/28572
     if input_dtype == np.dtype("float32"):
-        return convolve_f32(texture, u, v, kernel, iterations, uv_mode)  # type: ignore[arg-type, return-value, unused-ignore] # pyright: ignore[reportArgumentType, reportReturnType]
+        return convolve_f32(texture, u, v, kernel, uv_mode, iterations)  # type: ignore[arg-type, return-value, unused-ignore] # pyright: ignore[reportArgumentType, reportReturnType]
     elif input_dtype == np.dtype("float64"):
-        return convolve_f64(texture, u, v, kernel, iterations, uv_mode)  # type: ignore[arg-type, return-value, unused-ignore] # pyright: ignore[reportArgumentType, reportReturnType]
+        return convolve_f64(texture, u, v, kernel, uv_mode, iterations)  # type: ignore[arg-type, return-value, unused-ignore] # pyright: ignore[reportArgumentType, reportReturnType]
     else:
         raise RuntimeError  # pragma: no cover


### PR DESCRIPTION
Extracted from #169