### PR TITLE
PERF: make panics fatal errors, improving performance and reducing binary size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DOC: consistently indicate argument types (positional-only and keyword-only)
   in `rlic.convolve`'s docstring
 - DOC: fix invalid example code and re-generate output image
+- PERF: turn rust panics into fatal errors, improving performance and
+  reducing binary size by 10% each
+
 
 ## 0.3.4 - 2025-04-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ either = "1.14.0"
 [profile.release]
 # https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units
 codegen-units = 1
+# https://nnethercote.github.io/perf-book/build-configuration.html#abort-on-panic
+panic = "abort"


### PR DESCRIPTION
The only downside is that, in the incredibly unlikely event that the hotloop panics, the Python interpreter iwill now close instead of raising a (unactionable) exception. This seems acceptable in release builds, considering the gain in performance.
