### PR TITLE
DEP: drop support for NumPy 1.21.x, require >=1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PERF: turn rust panics into fatal errors, improving performance and
   reducing binary size by 10% each
 
+- DEP: drop support for NumPy 1.21.x, require 1.22.0 or newer
 
 ## 0.3.4 - 2025-04-09
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 requires-python = ">=3.9" # keep in sync with pyo3 (Cargo.toml)
 dependencies = [
     "exceptiongroup>=1.0.0 ; python_full_version < '3.11'", # keep in sync with typecheck dep group
-    "numpy>=1.21.0",
+    "numpy>=1.22.0",
 ]
 
 [project.readme]

--- a/uv.lock
+++ b/uv.lock
@@ -488,7 +488,7 @@ uv-only = [
 [package.metadata]
 requires-dist = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.0" },
-    { name = "numpy", specifier = ">=1.21.0" },
+    { name = "numpy", specifier = ">=1.22.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
This is done in support of #173, where I found that what's likely a bug in numpy<1.22 breaks regression tests.