### PR TITLE
TST: test Python 3.14 on macOS and Windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,14 @@ jobs:
 
   python-future-deps:
     name: Future Python dependencies
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Given I intend to claim compatibility with 3.14 in my next release (0.4.0), I should explicitly test it on all supported platforms. This isn't meant as a permanent addition to the test suite though, maybe I won't even merge this after CI passes. In any case, it should run on 3.14.0b3 today and it should soon be upgraded to 3.14.0b4 (depending on when uv supports it), so ideally I'll check both versions before closing.