### PR TITLE
TST: rewrite `test_exceptions.py` using pytest 8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ covcheck = [
     "coverage>=7.6.1 ; python_version >= '3.11'",
 ]
 test = [
-    "pytest>=8.1.0",
+    "pytest>=8.4.0",
 ]
 typecheck = [
     "exceptiongroup>=1.0.0", # keep in sync with conditional runtime dep

--- a/uv.lock
+++ b/uv.lock
@@ -422,9 +422,9 @@ requires-dist = [
 covcheck = [
     { name = "coverage", marker = "python_full_version >= '3.11'", specifier = ">=7.6.1" },
     { name = "coverage", extras = ["toml"], marker = "python_full_version < '3.11'", specifier = ">=7.6.1" },
-    { name = "pytest", specifier = ">=8.1.0" },
+    { name = "pytest", specifier = ">=8.4.0" },
 ]
-test = [{ name = "pytest", specifier = ">=8.1.0" }]
+test = [{ name = "pytest", specifier = ">=8.4.0" }]
 typecheck = [
     { name = "basedpyright", specifier = ">=1.26.0" },
     { name = "exceptiongroup", specifier = ">=1.0.0" },


### PR DESCRIPTION
pytest 8.4 introduced `RaisesGroup` and `RaisesExc`, which allow ditching my hacky helper function.