### PR TITLE
WHL: cross compile macos x86_64 wheels

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,8 @@ jobs:
   # adapted from
   # https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
   macos-intel:
-    runs-on: macos-13
+    # cross-compiling: no testing
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: astral-sh/setup-uv@05273c154d09957eb9a2377d9c988fbda431d1c5 # v6.4.0
@@ -89,12 +90,6 @@ jobs:
       with:
         target: x86_64
         args: --release --out dist
-    - name: Test wheel
-      run: |
-        uv sync --only-group test
-        uv pip install numpy
-        uv pip install rlic --no-index --find-links dist --no-deps
-        uv run --no-sync pytest --color=yes
     - name: Upload wheels
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:


### PR DESCRIPTION
`macos-13` is going away soon, but luckily, cross-compilation is still available so this should be trivial