### PR TITLE
ENH: enable FMA for x86_64 targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WHL: add support for Windows-arm64 targets
 - DOC: document stability guarantees and free-threading support
+- ENH: enable FMA for x86_64 targets
 
 ## 0.5.1 - 2025-07-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ codegen-units = 1
 panic = "abort"
 # https://nnethercote.github.io/perf-book/build-configuration.html#strip-debug-info-and-symbols
 strip = "symbols"
+
+# https://jlogan.dev/blog/2025/11/10/2025-11-10-interpn-fast-interpolation/
+[target.'cfg(any(target_arch = "x86_64", target_arch = "x64"))']
+rustflags = ["-C", "target-feature=+fma"]


### PR DESCRIPTION
Although this should provide a marginal performance gain, this is mostly about improving floating point error consistency across platforms.