### PR TITLE
BLD: use a reference target CPU instead of specific instructions (FMA) for x86-64 targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ panic = "abort"
 # https://nnethercote.github.io/perf-book/build-configuration.html#strip-debug-info-and-symbols
 strip = "symbols"
 
-# https://jlogan.dev/blog/2025/11/10/2025-11-10-interpn-fast-interpolation/
+# https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x64"))']
-rustflags = ["-C", "target-feature=+fma"]
+rustflags = ["-C", "target-cpu=x86-64-v3"] # circa 2013


### PR DESCRIPTION
follow up to #250