### PR TITLE
WHL: build macos-x86_64 wheels natively again, and ensure they are tested

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,11 +73,8 @@ jobs:
         uv pip install .
         uv run --no-project pytest --color=yes -ra
 
-  # adapted from
-  # https://github.com/messense/crfs-rs/blob/main/.github/workflows/Python.yml
   macos-intel:
-    # cross-compiling: no testing
-    runs-on: macos-latest
+    runs-on: macos-15-intel
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
@@ -98,6 +95,12 @@ jobs:
       with:
         target: x86_64
         args: --release --out dist --no-default-features -F fma
+    - name: Test wheel
+      run: |
+        uv sync --only-group test
+        uv pip install numpy
+        uv pip install rlic --no-index --find-links dist --no-deps
+        uv run --no-sync pytest --color=yes
     - name: Upload wheels
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
        build configurations. These bugs were introduced in version 0.5.2
 - WHL: re-enable fma on manylinux x86_64 wheels, and disable branchless execution,
        bringing this build's configuration in line with the equivalent macos target
+- WHL: build macos-x86_64 wheels natively again, and ensure they are tested
 
 ## 0.5.2 - 2025-11-14
 


### PR DESCRIPTION
close #262