### PR TITLE
BUG: fix time_to_next_pixel computation with branchless (and without fma) features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - BLD: warning free builds in any configuration
+- BUG: fix time_to_next_pixel computation with branchless (and without fma)
+       This bug was introduced in rlic 0.5.2
 
 ## 0.5.2 - 2025-11-14
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,6 @@ impl AtLeastF32 for f32 {}
 impl AtLeastF32 for f64 {}
 
 fn time_to_next_pixel<T: AtLeastF32>(velocity: T, current_frac: T) -> T {
-    // this is the branchless version of
     #[cfg(not(feature = "branchless"))]
     {
         if velocity > 0.0.into() {
@@ -166,13 +165,13 @@ fn time_to_next_pixel<T: AtLeastF32>(velocity: T, current_frac: T) -> T {
     #[cfg(feature = "branchless")]
     {
         let one: T = 1.0.into();
-        let two: T = 2.0.into();
-        let mtwo = -two;
+        let half: T = 0.5.into();
         let d1 = current_frac;
+
         #[cfg(not(feature = "fma"))]
-        let remaining_frac = (one + signum(velocity)) * (mtwo * d1 + one / two) + d1;
+        let remaining_frac = (one + signum(velocity)) * (half - d1) + d1;
         #[cfg(feature = "fma")]
-        let remaining_frac = (one + signum(velocity)).mul_add((mtwo.mul_add(d1, one)) / two, d1);
+        let remaining_frac = (one + signum(velocity)).mul_add(half - d1, d1);
         abs(remaining_frac / velocity)
     }
 }


### PR DESCRIPTION
follow up to https://github.com/neutrinoceros/rlic/pull/173

fix a bug I think was introduced in #253