### PR TITLE
FEAT: add a public `rlic.equalize_histogram` post-processing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - WHL: disable branchless execution on windows x86_64 wheels
+- FEAT: add a public `rlic.equalize_histogram` post-processing function
 
 ## 0.5.3 - 2025-11-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,11 +117,14 @@ exclude_also = [
 [tool.pyright]
 reportImplicitStringConcatenation = false
 reportUnnecessaryTypeIgnoreComment = false # todo: drop this when Python 3.10 is EOL
+reportIgnoreCommentWithoutRule = false
+enableTypeIgnoreComments = true
 
 [tool.mypy]
 strict = true
 show_error_codes = true
 show_error_context = true
+warn_unused_ignores = false
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/rlic/__init__.py
+++ b/src/rlic/__init__.py
@@ -1,5 +1,8 @@
-"""Line Integral Convolution, implemented in Rust."""
+"""Line Integral Convolution, written in Rust."""
 
-__all__ = ["convolve"]
+__all__ = [
+    "convolve",
+    "equalize_histogram",
+]
 
-from rlic._lib import convolve
+from rlic._lib import convolve, equalize_histogram

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+
+import rlic
+
+
+@pytest.mark.parametrize(
+    "bins, min_rms_reduction",
+    [
+        (12, 2.0),
+        (64, 10.0),
+        (256, 50.0),
+    ],
+)
+def test_historgram_equalization(bins, min_rms_reduction):
+    # histogram equalization produces a new image whose cumulative
+    # distribution function (cdf) should be close(r) to a straight line
+    # (i.e., approaching a flat intensity distribution)
+    # This test check this property from an initial image made of gaussian
+    # noise.
+    # Expected rms reduction factors (min_rms_reduction) are empirical, i.e.,
+    # slightly looser than what the original implementation was able to achieve
+
+    IMAGE_SHAPE = (256, 128)
+    prng = np.random.default_rng(0)
+    image = prng.normal(size=np.prod(IMAGE_SHAPE)).reshape(IMAGE_SHAPE)
+
+    def normalized_cdf(a):
+        hist, bin_edges = np.histogram(a.ravel(), bins=bins)
+        cdf = hist.cumsum()
+        return cdf / float(cdf.max())
+
+    def rms(a, b):
+        return np.sqrt(np.mean((a - b) ** 2))
+
+    image_eq = rlic.equalize_histogram(image, bins=bins)
+    cdf_in = normalized_cdf(image)
+    cdf_eq = normalized_cdf(image_eq)
+
+    id_func = np.linspace(0, 1, bins)
+    rms_in = rms(cdf_in, id_func)
+    rms_eq = rms(cdf_eq, id_func)
+    assert (rms_eq / rms_in) < min_rms_reduction


### PR DESCRIPTION
This is upstreamed from `lick`. I think it makes sense to have this commonly-needed function within the core package as it's very light, commonly duplicated and doesn't require any new dependency.


TODO:
update documentation