### PR TITLE
API: rename 'sliding-window' into 'sliding-tile' to improve API consistency

### DIFF
--- a/src/rlic/_histeq.py
+++ b/src/rlic/_histeq.py
@@ -16,14 +16,14 @@ else:
         assert_never,
     )
 
-SUPPORTED_KINDS = frozenset({"sliding-window"})
-StrategyKind: TypeAlias = Literal["sliding-window"]
+SUPPORTED_KINDS = frozenset({"sliding-tile"})
+StrategyKind: TypeAlias = Literal["sliding-tile"]
 
 
-SlidingWindowSpec = TypedDict(
-    "SlidingWindowSpec",
+SlidingTileSpec = TypedDict(
+    "SlidingTileSpec",
     {
-        "kind": Literal["sliding-window"],
+        "kind": Literal["sliding-tile"],
         "tile-size": NotRequired[PairSpec[int]],
         "tile-size-max": NotRequired[PairSpec[int]],
     },
@@ -55,11 +55,11 @@ class Strategy:
     tile_size_max: Pair[int] | None = None
 
     @staticmethod
-    def from_spec(spec: SlidingWindowSpec, /) -> "Strategy":
+    def from_spec(spec: SlidingTileSpec, /) -> "Strategy":
         match kind := spec.get("kind"):
             case None:  # pyright: ignore[reportUnnecessaryComparison]
                 raise TypeError("strategy dict is missing a 'kind' key.")  # pyright: ignore[reportUnreachable]
-            case "sliding-window":
+            case "sliding-tile":
                 pass
             case _:  # pyright: ignore[reportUnnecessaryComparison]
                 raise ValueError(  # pyright: ignore[reportUnreachable]

--- a/src/rlic/_lib.py
+++ b/src/rlic/_lib.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from numpy import float32 as f32
     from numpy import float64 as f64
 
-    from rlic._histeq_adaptive_strategy import SlidingWindowSpec
+    from rlic._histeq import SlidingTileSpec
     from rlic._typing import Boundary, BoundarySpec, Pair, UVMode
 
     F = TypeVar("F", f32, f64)
@@ -248,7 +248,7 @@ def equalize_histogram(
     *,
     nbins: int = 256,
     boundaries: Boundary | BoundarySpec = "closed",
-    adaptive_strategy: SlidingWindowSpec | None = None,
+    adaptive_strategy: SlidingTileSpec | None = None,
     contrast_limitation: None = None,
 ) -> ndarray[tuple[int, int], dtype[F]]:
     """Equalize histogram of a gray-scale image.
@@ -271,7 +271,7 @@ def equalize_histogram(
       Only 'closed' boundaries are accepted at the moment.
       https://github.com/neutrinoceros/rlic/issues/303
 
-    adaptive_strategy: None (default) or a sliding-window specification, keyword-only
+    adaptive_strategy: None (default) or a sliding-tile specification, keyword-only
       not implemented
       https://github.com/neutrinoceros/rlic/issues/301
       https://github.com/neutrinoceros/rlic/issues/302

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 import pytest
 
 import rlic
-from rlic._histeq_adaptive_strategy import Strategy
+from rlic._histeq import Strategy
 
 
 def test_missing_strategy_kind():
@@ -16,7 +16,7 @@ def test_unknown_strategy_kind():
         ValueError,
         match=(
             r"^Unknown strategy kind 'not-a-kind'\. "
-            r"Expected one of \['sliding-window'\]$"
+            r"Expected one of \['sliding-tile'\]$"
         ),
     ):
         Strategy.from_spec({"kind": "not-a-kind"})
@@ -30,7 +30,7 @@ def test_sliding_window_missing_tile_size():
             r"Either are allowed, but exactly one is expected\."
         ),
     ):
-        Strategy.from_spec({"kind": "sliding-window"})
+        Strategy.from_spec({"kind": "sliding-tile"})
 
 
 @pytest.mark.parametrize("key", ["tile-size", "tile-size-max"])
@@ -43,7 +43,7 @@ def test_sliding_window_invalid_type_tile_size(key):
             r"Expected a single int, or a pair thereof\."
         ),
     ):
-        Strategy.from_spec({"kind": "sliding-window", key: 1.5})
+        Strategy.from_spec({"kind": "sliding-tile", key: 1.5})
 
 
 def test_sliding_window_both_tile_sizes_keys():
@@ -55,7 +55,7 @@ def test_sliding_window_both_tile_sizes_keys():
         ),
     ):
         Strategy.from_spec(
-            {"kind": "sliding-window", "tile-size": 11, "tile-size-max": 13}
+            {"kind": "sliding-tile", "tile-size": 11, "tile-size-max": 13}
         )
 
 
@@ -63,23 +63,23 @@ def test_sliding_window_both_tile_sizes_keys():
     "spec, expected",
     [
         pytest.param(
-            {"kind": "sliding-window", "tile-size": 13},
-            Strategy(kind="sliding-window", tile_size=(13, 13)),
+            {"kind": "sliding-tile", "tile-size": 13},
+            Strategy(kind="sliding-tile", tile_size=(13, 13)),
             id="int-tile-size",
         ),
         pytest.param(
-            {"kind": "sliding-window", "tile-size": (13, 15)},
-            Strategy(kind="sliding-window", tile_size=(13, 15)),
+            {"kind": "sliding-tile", "tile-size": (13, 15)},
+            Strategy(kind="sliding-tile", tile_size=(13, 15)),
             id="tuple-tile-size",
         ),
         pytest.param(
-            {"kind": "sliding-window", "tile-size-max": 13},
-            Strategy(kind="sliding-window", tile_size_max=(13, 13)),
+            {"kind": "sliding-tile", "tile-size-max": 13},
+            Strategy(kind="sliding-tile", tile_size_max=(13, 13)),
             id="int-tile-size-max",
         ),
         pytest.param(
-            {"kind": "sliding-window", "tile-size-max": (13, 15)},
-            Strategy(kind="sliding-window", tile_size_max=(13, 15)),
+            {"kind": "sliding-tile", "tile-size-max": (13, 15)},
+            Strategy(kind="sliding-tile", tile_size_max=(13, 15)),
             id="tuple-tile-size-max",
         ),
     ],


### PR DESCRIPTION
I also renamed the private module while I was at it.