### PR TITLE
TST: rework strat parsing test to avoid checking for error messages on future-valid inputs (-1)

### DIFF
--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -80,8 +80,8 @@ def test_sliding_tile_both_tile_sizes_keys():
 @pytest.mark.parametrize(
     "size, axis, msg",
     [
-        ((-1, 3), "x", MSG_TOO_LOW),
-        ((3, -1), "y", MSG_TOO_LOW),
+        ((1, 3), "x", MSG_TOO_LOW),
+        ((3, 1), "y", MSG_TOO_LOW),
         ((4, 3), "x", MSG_EVEN),
         ((3, 4), "y", MSG_EVEN),
     ],


### PR DESCRIPTION
I plan to allow -1 as a special case to mean "match the image size", so it should not be rejected in tests.
