### PR TITLE
BUG: fix panics in histogram equalization algorithms when intensities are uniform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod test_pixel_select {
     }
 }
 
-trait AtLeastF32: Float + From<f32> + Signed + AddAssign<<Self as Mul>::Output> + std::fmt::Display + std::fmt::Debug {}
+trait AtLeastF32: Float + From<f32> + Signed + AddAssign<<Self as Mul>::Output> {}
 impl AtLeastF32 for f32 {}
 impl AtLeastF32 for f64 {}
 
@@ -667,6 +667,13 @@ where
     for v in arr.iter() {
         lo = lo.min(*v);
         hi = hi.max(*v);
+    }
+    if hi == lo {
+        if hi == 0.0.into() {
+            hi = 1.0.into();
+        } else {
+            lo = 0.0.into();
+        }
     }
     Range { lo, hi }
 }

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -505,7 +505,6 @@ def test_minimal_size_divisor(size, into, expected):
     assert minimal_divisor_size(size, into) == expected
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "adaptive_strategy",
     [


### PR DESCRIPTION
close neutrinoceros/ahe#9
close neutrinoceros/rlic#388

I also discovered that applying histeq to a uniform region of 0.0 intensities would result in a uniform region with 1.0 everywhere. I don't think that's a bug so much as an edge case, but maybe I'll revisit this some other time.