### PR TITLE
TST: finish pytest conf format migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ exclude = [
     "_typos.toml",
 ]
 
-[tool.pytest.ini_options]
+[tool.pytest]
 minversion = "9.0"
 strict = true
 addopts = ["-ra"]


### PR DESCRIPTION
I already moved the table format to toml but forgot to rename it appropriately.